### PR TITLE
avoid move event crash

### DIFF
--- a/cocos/new-ui/event-system/event-system.ts
+++ b/cocos/new-ui/event-system/event-system.ts
@@ -90,6 +90,10 @@ export class EventSystem {
     public handleMouseEvent (event: Event, ray: Ray) {
         const eventMouse = event as EventMouse;
         const button = eventMouse.getButton();
+        if(button<0){
+            // the event might be move which is not handled with.
+            return;
+        }
         let curMouseButtonEvent: MouseButtonEvent | null = null;
 
         if (button === EventMouse.BUTTON_LEFT) {


### PR DESCRIPTION
Re:

Changes:
 * handleMouseEvent cannot handle with move event. Avoid it temperarily

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!

- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.

- For official teams:
  - [ ] Check that your javascript is following our [style guide](https://docs.cocos.com/creator/manual/zh/scripting/reference/coding-standards.html) and end files with a newline
  - [ ] Document new code with comments in source code based on [API Docs](https://github.com/cocos-creator/fireball#api-docs)
  - [ ] Make sure any **runtime** log information in `cc.log`, `cc.error` or `new Error()` has been moved into `EngineErrorMap.md` with an ID, and use `cc.logID(id)` or `new Error(cc.debug.getError(id))` instead.

-->
